### PR TITLE
Matbench wide logger

### DIFF
--- a/matbench/base.py
+++ b/matbench/base.py
@@ -2,34 +2,49 @@
 Base classes, mixins, and other inheritables.
 """
 
-__authors__ = ["Alex Dunn <ardunn@lbl.gov>"]
+import logging
+from matbench.utils.utils import initialize_logger, initialize_null_logger
+
+__authors__ = ["Alex Dunn <ardunn@lbl.gov>", "Alex Ganose <aganose@lbl.gov>"]
 
 
-class LoggableMixin:
-    """
-    A mixin class for easy logging (or absence of it).
-    """
-    def _log(self, lvl, msg):
+class LoggableMixin(object):
+    """A mixin class for easy logging (or absence of it)."""
+
+    @property
+    def logger(self):
+        """Get the class logger.
+
+        If the logger is None, the logging calls will be redirected to a dummy
+        logger that has no output.
         """
-        Convenience method for logging.
+        if hasattr(self, "_logger"):
+            return self._logger
+        else:
+            raise AttributeError("Loggable object has no _logger attribute!")
+
+    def get_logger(self, logger):
+        """Set the class logger.
 
         Args:
-            lvl (str): Level of the log message, either "info", "warn", or "debug"
-            msg (str): The message for the logger.
-
-        Returns:
-            None
+            logger (Logger, bool): A custom logger object to use for logging.
+                Alternatively, if set to True, the default matbench logger will
+                be used. If set to False, then no logging will occur.
         """
-        if hasattr(self, "logger"):
-            if self.logger is not None:
-                if lvl == "warn":
-                    self.logger.warning(msg)
-                elif lvl == "info":
-                    self.logger.info(msg)
-                elif lvl == "debug":
-                    self.logger.debug(msg)
-        else:
-            raise AttributeError("Loggable object has no logger attr!")
+        # need comparison to True and False to avoid overwriting Logger objects
+        if logger is True:
+            logger = logging.getLogger(self.__module__.split('.')[0])
+
+            if not logger.handlers:
+                initialize_logger()
+
+        elif logger is False:
+            logger = logging.getLogger(self.__module__.split('.')[0] + "_null")
+
+            if not logger.handlers:
+                initialize_null_logger()
+
+        return logger
 
 
 class DataframeTransformer:
@@ -38,12 +53,12 @@ class DataframeTransformer:
     and BaseEstimator in sklearn.
     """
     def fit(self, df, target):
-        raise NotImplementedError("{} has no fit method implemented!".format(self.__class__.__name__))
+        raise NotImplementedError("{} has no fit method implemented!".format(
+            self.__class__.__name__))
 
     def transformer(self, df, target):
-        raise NotImplementedError("{} has no transform method implemented!".format(self.__class__.__name__))
+        raise NotImplementedError("{} has no transform method implemented!".
+                                  format(self.__class__.__name__))
 
     def fit_transform(self, df, target):
         return self.fit(df, target).transform(df, target)
-
-

--- a/matbench/featurization/core.py
+++ b/matbench/featurization/core.py
@@ -1,17 +1,16 @@
-import logging
-
 from matminer.featurizers.conversions import (CompositionToOxidComposition,
                                               StructureToOxidStructure)
 from pymatgen import Composition, Structure
 from pymatgen.electronic_structure.bandstructure import BandStructure
 from pymatgen.electronic_structure.dos import CompleteDos
 
-from matbench.utils.utils import MatbenchError, setup_custom_logger
+from matbench.base import LoggableMixin
+from matbench.utils.utils import MatbenchError
 from matbench.featurization.sets import CompositionFeaturizers, \
     StructureFeaturizers, BSFeaturizers, DOSFeaturizers
 
 
-class Featurization(object):
+class Featurization(LoggableMixin):
     """
     Takes in a dataframe and generate features from preset columns such as
     "formula", "structure", "bandstructure", "dos", etc. One may use
@@ -41,19 +40,15 @@ class Featurization(object):
             pass target = ("Input Data", "gap") in classes such as PreProcess.
         n_jobs (int): number of CPUs/workers used in featurization. Default
             behavior is matminer's default behavior.
+        logger (Logger, bool): A custom logger object to use for logging.
+            Alternatively, if set to True, the default matbench logger will be
+            used. If set to False, then no logging will occur.
     """
 
     def __init__(self, ignore_cols=None, ignore_errors=True,
                  drop_featurized_col=True, exclude=None, multiindex=False,
-                 n_jobs=None, logger=None):
-
-        if logger is None:
-            # Log to the current directory
-            self.logger = setup_custom_logger(filepath='.', level=logging.INFO)
-        else:
-            # Use the passed logger
-            self.logger = logger
-
+                 n_jobs=None, logger=True):
+        self._logger = self.get_logger(logger)
         self.ignore_cols = ignore_cols or []
         self.cfset = CompositionFeaturizers(exclude=exclude)
         self.sfset = StructureFeaturizers(exclude=exclude)

--- a/matbench/utils/utils.py
+++ b/matbench/utils/utils.py
@@ -1,4 +1,3 @@
-import importlib
 import logging
 import os
 import sys
@@ -17,34 +16,46 @@ class MatbenchError(BaseException):
         return "MatbenchError : " + self.msg
 
 
-def setup_custom_logger(name='matbench_logger', filepath='.',
-                        filename='matbench.log', level=None):
-    """
-    Custom logger with both screen and file handlers. This is particularly
-    useful if there are other programs that call on logging
-    in which case the log results and their levels are distinct and clear.
+def initialize_logger(filepath='.', filename=None, level=None):
+    """Initialize the default logger with stdout and file handlers.
 
     Args:
-        name (str): logger name to distinguish between different codes.
-        filepath (str): path to the folder where the logfile is meant to be
-        filename (str): log file filename
-        level (int): log level in logging package; example: logging.DEBUG
+        filepath (str): Path to the folder where the log file will be written.
+        filename (str): The log filename.
+        level (int): The log level. For example logging.DEBUG.
 
-    Returns: a logging instance with customized formatter and handlers
+    Returns:
+        (Logger): A logging instance with customized formatter and handlers.
     """
+    package_name = MatbenchError.__module__.split('.')[0]
+
     level = level or logging.INFO
-    logger = logging.getLogger(name)
-    importlib.reload(logging)
+    filename = filename or package_name + ".log"
+
+    logger = logging.getLogger(package_name)
     formatter = logging.Formatter(fmt='%(asctime)s %(levelname)-8s %(message)s',
                                   datefmt='%Y-%m-%d %H:%M:%S')
+
     handler = logging.FileHandler(os.path.join(filepath, filename), mode='w')
     handler.setFormatter(formatter)
     screen_handler = logging.StreamHandler(stream=sys.stdout)
     screen_handler.setFormatter(formatter)
+
     logger.setLevel(level)
     logger.addHandler(screen_handler)
     logger.addHandler(handler)
+    return logger
 
+
+def initialize_null_logger():
+    """Initialize the a dummy logger which will swallow all logging commands.
+
+    Returns:
+        (Logger): A dummy logging instance with no output.
+    """
+    package_name = MatbenchError.__module__.split('.')[0]
+    logger = logging.getLogger(package_name + "_null")
+    logger.addHandler(logging.NullHandler())
     return logger
 
 


### PR DESCRIPTION
Addressing  #103. 

This implements a package wide logger. Allows allows for the user to set no logging.

An example of how this should be used is in the `Featurization` class:

```python
class Featurization(LoggableMixin):
    """
    Takes in a dataframe and generate features from preset columns such as

    ...

        logger (Logger, bool): A custom logger object to use for logging.
            Alternatively, if set to True, the default matbench logger will be
            used. If set to False, then no logging will occur.
    """
     def __init__(self, ignore_cols=None, ignore_errors=True,
                 drop_featurized_col=True, exclude=None, multiindex=False,
                 n_jobs=None, logger=True):
        self._logger = self.get_logger(logger)
```

The logger can then be used as:

```python
self.logger.info("message")
```