### PR TITLE
Slight error in pipe.benchmark()

### DIFF
--- a/examples/MSE_Example.ipynb
+++ b/examples/MSE_Example.ipynb
@@ -80,7 +80,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "predicted = pipe.benchmark(df, \"K_VRH\", test_spec=0.2)"
+    "kfold = KFold(n_splits=5)",
+    "predicted = pipe.benchmark(df, \"K_VRH\", kfold)"
    ]
   },
   {


### PR DESCRIPTION
The parameters of benchmark have changed since the time this example was created. Benchmark currently requires a kfold parameter so I removed the previous test_spec parameter and passed in a KFold object.