### PR TITLE
make DFTransformer inherit BaseEstimator

### DIFF
--- a/automatminer/base.py
+++ b/automatminer/base.py
@@ -3,7 +3,7 @@ Base classes, mixins, and other inheritables.
 """
 import abc
 import logging
-
+from sklearn.base import BaseEstimator
 from automatminer.utils.log import initialize_logger, \
     initialize_null_logger, AMM_LOGGER_BASENAME
 
@@ -54,7 +54,7 @@ class LoggableMixin:
         return self.__class__.__name__ + ": "
 
 
-class DFTransformer(abc.ABC):
+class DFTransformer(abc.ABC, BaseEstimator):
     """ A base class to allow easy transformation in the same way as
     TransformerMixin and BaseEstimator in sklearn, but for pandas dataframes.
 


### PR DESCRIPTION
## Summary

Make `DFTransformer` inherit `BaseEstimator`

* `get_params` and `set_params` can be used.
* `print(MatPipe())`, as an example, can give somewhat better output (good for demo):

previously: 
```
print(MatPipe())
<automatminer.pipeline.MatPipe object at 0x12a14cfd0> 
```

now:
```
print(MatPipe())
MatPipe(autofeaturizer=AutoFeaturizer(bandstructure_col=None, cache_src=None,
        composition_col='composition', do_precheck=True, dos_col='dos',
        drop_inputs=True, exclude=[],
        featurizers={'composition': [AtomicOrbitals(), ElementProperty(data_source=<matminer.utils.data.PymatgenData obj...er (INFO)>,
        multiindex=False, n_jobs=None, preset='best',
        structure_col='structure'),
      cleaner=DataCleaner(drop_na_targets=True, encode_categories=True, encoder='one-hot',
        feature_na_method='drop', logger=<Logger automatminer (INFO)>,
        max_na_frac=0.01, na_method_fit='drop', na_method_transform='fill'),
      learner=TPOTAdaptor(logger=<Logger automatminer (INFO)>),
      log_level=None, logger=<Logger automatminer (INFO)>,
      reducer=FeatureReducer(corr_threshold=0.95, keep_features=None,
        logger=<Logger automatminer (INFO)>, n_pca_features='auto',
        n_rebate_features=0.3, reducers=('pca',), remove_features=None,
        tree_importance_percentile=0.9))

```