### PR TITLE
Add support for pipeline digest in JSON and YAML format

### DIFF
--- a/automatminer/pipeline.py
+++ b/automatminer/pipeline.py
@@ -1,12 +1,12 @@
 """
 The highest level classes for pipelines.
 """
+import json
 import os
 import pickle
 from pprint import pformat
-import json
-import yaml
 
+import yaml
 from automatminer.base import LoggableMixin, DFTransformer
 from automatminer.presets import get_preset_config
 from automatminer.utils.ml import regression_or_classification
@@ -279,14 +279,17 @@ class MatPipe(DFTransformer, LoggableMixin):
         """
         attrs = return_attrs_recursively(self)
 
-        if (
+        def format_one_of(fmts):
+            return (
             filename
-            and filename.lower().endswith((".json", ".yaml", ".yml"))
-            or output_format in ("json", "yaml", "yml")
-        ):
-            digeststr = json.dumps(attrs, default=lambda x: "<not serializable>")
-            if filename.lower().endswith((".yaml", ".yml")) or output_format in ("yaml", "yml"):
-                digeststr = yaml.dump(yaml.load(digeststr))
+                and filename.lower().endswith(tuple(["." + f for f in fmts]))
+                or output_format in fmts
+            )
+
+        if format_one_of(("json", "yaml", "yml")):
+            digeststr = json.dumps(attrs, default=lambda x: str(x))
+            if format_one_of(("yaml", "yml")):
+                digeststr = yaml.dump(yaml.safe_load(digeststr))
         else:
             digeststr = pformat(attrs)
 

--- a/automatminer/tests/test_pipeline.py
+++ b/automatminer/tests/test_pipeline.py
@@ -17,7 +17,8 @@ from automatminer.utils.pkg import AutomatminerError
 
 test_dir = os.path.dirname(__file__)
 CACHE_SRC = os.path.join(test_dir, "cache.json")
-DIGEST_PATH = os.path.join(test_dir, "matdigest.txt")
+DIGEST_PATH = os.path.join(test_dir, "matdigest.")
+DIGEST_EXTS = ['txt', 'json', 'yml', 'yaml']
 PIPE_PATH = os.path.join(test_dir, "test_pipe.p")
 
 
@@ -124,9 +125,13 @@ class TestMatPipe(unittest.TestCase):
         self.assertTrue(self.target + " predicted" in df_test.columns)
 
         digest_file = os.path.join(test_dir, DIGEST_PATH)
-        digest = self.pipe.digest(filename=digest_file)
-        self.assertTrue(os.path.isfile(digest_file))
-        self.assertTrue(isinstance(digest, str))
+        for ext in DIGEST_EXTS:
+            digest = self.pipe.digest(filename=digest_file + ext)
+            self.assertTrue(os.path.isfile(digest_file + ext))
+            self.assertTrue(isinstance(digest, str))
+            
+            digest = self.pipe.digest(output_format=ext)
+            self.assertTrue(isinstance(digest, str))
 
     def _run_benchmark(self, cache, pipe):
         # Test static, regular benchmark (no fittable featurizers)
@@ -146,6 +151,6 @@ class TestMatPipe(unittest.TestCase):
         self.assertEqual(len(df_tests2), 2)
 
     def tearDown(self):
-        for remnant in [CACHE_SRC, PIPE_PATH, DIGEST_PATH]:
+        for remnant in [CACHE_SRC, PIPE_PATH, *[DIGEST_PATH + ext for ext in DIGEST_EXTS]]:
             if os.path.exists(remnant):
                 os.remove(remnant)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ xlrd==1.1.0
 xgboost==0.80
 tpot==0.10.1
 skrebate==0.6
+pyyaml==5.1.2
 
 # Also requirements of matminer
 numpy


### PR DESCRIPTION
Let me know if you would like me to add some tests. I tried running the one's that are already there but  `pytest` has been stuck on `test_adaptors.py` for half an hour now.