### PR TITLE
Code style enforcement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.21
+    hooks:
+      - id: isort
+        language_version: python3.7
+  - repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+      - id: black
+        language_version: python3.7
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: flake8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,44 +1,64 @@
 # Contributing to automatminer
+
 We love your input! We want to make contributing to automatminer as easy and transparent as possible, whether it's:
-*   Reporting a bug
-*   Discussing the current state of the code
-*   Submitting a fix
-*   Proposing or implementing new features
-*   Becoming a maintainer
+
+- Reporting a bug
+- Discussing the current state of the code
+- Submitting a fix
+- Proposing or implementing new features
+- Becoming a maintainer
 
 ## Reporting bugs, getting help, and discussion
+
 At any time, feel free to start a thread on the automatminer [Discourse forum](https://hackingmaterials.discourse.group/c/matminer/automatminer).
 
 If you are making a bug report, incorporate as many elements of the following as possible to ensure a timely response and avoid the need for followups:
-*   A quick summary and/or background
-*   Steps to reproduce - be specific! **Provide sample code.**
-*   What you expected would happen, compared to what actually happens
-*   The full stack trace of any errors you encounter
-*   Notes (possibly including why you think this might be happening, or steps you tried that didn't work)
+
+- A quick summary and/or background
+- Steps to reproduce - be specific! **Provide sample code.**
+- What you expected would happen, compared to what actually happens
+- The full stack trace of any errors you encounter
+- Notes (possibly including why you think this might be happening, or steps you tried that didn't work)
 
 We love thorough bug reports as this means the development team can make quick and meaningful fixes. When we confirm your bug report, we'll move it to the GitHub issues where its progress can be further tracked.
 
-## Contributing code modifications or additions through Github
-We use github to host code, to track issues and feature requests, as well as accept pull requests.
+## Contributing code modifications or additions through GitHub
 
-Pull requests are the best way to propose changes to the codebase. Follow the [Github flow](https://www.atlassian.com/git/tutorials/comparing-workflows/forking-workflow) for more information on this procedure.
+We use GitHub to host code, to track issues and feature requests, as well as accept pull requests.
+
+Pull requests are the best way to propose changes to the codebase. Follow the [GitHub flow](https://www.atlassian.com/git/tutorials/comparing-workflows/forking-workflow) for more information on this procedure.
 
 The basic procedure for making a PR is:
-*   Fork the repo and create your branch from master.
-*   Commit your improvements to your branch and push to your Github fork (repo).
-*   When you're finished, go to your fork and make a Pull Request. It will automatically update if you need to make further changes.
+
+- Fork the repo on GitHub and clone it to your machine.
+
+  ```sh
+  git clone https://github.com/<your_github_name>/automatminer
+  ```
+
+- Install both regular and development dependencies and setup the `git` pre-commit hook.
+  
+  ```sh
+  pip install -r requirements.txt requirement && pre-commit install
+  ```
+
+  This step is important as your changes may otherwise contain style violations that will throw errors when running our CI on your pull request.
+- Commit your improvements and push to your GitHub fork.
+- When you're finished, go to your fork and make a pull request. It will automatically update if you need to make further changes.
 
 ### How to Make a **Great** Pull Request
+
 We have a few tips for writing good PRs that are accepted into the main repo:
 
-*   Use the Google Code style for all of your code. Find an example [here.](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
-*   Your code should have (4) spaces instead of tabs.
-*   If needed, update the documentation.
-*   **Write tests** for new features! Good tests are 100%, absolutely necessary for good code. We use the python `unittest` framework -- see some of the other tests in this repo for examples, or review the [Hitchhiker's guide to python](https://docs.python-guide.org/writing/tests/) for some good resources on writing good tests.
-*   Understand your contributions will fall under the same license as this repo. 
+- Use the Google Code style for all of your code. Find an example [here.](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
+- Your code should have (4) spaces instead of tabs.
+- If needed, update the documentation.
+- **Write tests** for new features! Good tests are 100%, absolutely necessary for good code. We use the python `unittest` framework -- see some of the other tests in this repo for examples, or review the [Hitchhiker's guide to python](https://docs.python-guide.org/writing/tests/) for some good resources on writing good tests.
+- Understand your contributions will fall under the same license as this repo.
 
-When you submit your PR, our CI service will automatically run your tests. 
+When you submit your PR, our CI service will automatically run your tests.
 We welcome good discussion on the best ways to write your code, and the comments on your PR are an excellent area for discussion.
 
 #### References
-This document was adapted from the open-source contribution guidelines for Facebook's Draft, as well as briandk's [contribution template](https://gist.github.com/briandk/3d2e8b3ec8daf5a27a62). 
+
+This document was adapted from the open-source contribution guidelines for Facebook's Draft, as well as briandk's [contribution template](https://gist.github.com/briandk/3d2e8b3ec8daf5a27a62).

--- a/automatminer/__init__.py
+++ b/automatminer/__init__.py
@@ -1,10 +1,10 @@
-from automatminer.preprocessing import DataCleaner, FeatureReducer
-from automatminer.automl import TPOTAdaptor, SinglePipelineAdaptor
-from automatminer.featurization import AutoFeaturizer
-from automatminer.pipeline import MatPipe
-from automatminer.presets import get_preset_config
+from automatminer.automl import SinglePipelineAdaptor, TPOTAdaptor  # noqa
+from automatminer.featurization import AutoFeaturizer  # noqa
+from automatminer.pipeline import MatPipe  # noqa
+from automatminer.preprocessing import DataCleaner, FeatureReducer  # noqa
+from automatminer.presets import get_preset_config  # noqa
 
-__author__ = 'Alex Dunn, Qi Wang, Alex Ganose, Alireza Faghaninia, Anubhav Jain'
-__author_email__ = 'ardunn@lbl.gov'
-__license__ = 'Modified BSD'
+__author__ = "Alex Dunn, Qi Wang, Alex Ganose, Alireza Faghaninia, Anubhav Jain"
+__author_email__ = "ardunn@lbl.gov"
+__license__ = "Modified BSD"
 __version__ = "2019.10.14"

--- a/automatminer/base.py
+++ b/automatminer/base.py
@@ -3,9 +3,13 @@ Base classes, mixins, and other inheritables.
 """
 import abc
 import logging
+
+from automatminer.utils.log import (
+    AMM_LOGGER_BASENAME,
+    initialize_logger,
+    initialize_null_logger,
+)
 from sklearn.base import BaseEstimator
-from automatminer.utils.log import initialize_logger, \
-    initialize_null_logger, AMM_LOGGER_BASENAME
 
 __authors__ = ["Alex Dunn <ardunn@lbl.gov>", "Alex Ganose <aganose@lbl.gov>"]
 
@@ -24,7 +28,7 @@ class LoggableMixin:
     @logger.setter
     def logger(self, new_logger):
         """Set a new logger.
-        
+
         Args:
             new_logger (Logger, bool): A boolean or custom logger object to use
             for logging. Alternatively, if set to True, the default automatminer

--- a/automatminer/preprocessing/__init__.py
+++ b/automatminer/preprocessing/__init__.py
@@ -1,1 +1,1 @@
-from .core import DataCleaner, FeatureReducer
+from .core import DataCleaner, FeatureReducer  # noqa

--- a/automatminer/preprocessing/feature_selection.py
+++ b/automatminer/preprocessing/feature_selection.py
@@ -2,20 +2,22 @@
 Various in-house feature reduction techniques.
 """
 import numpy as np
+from automatminer.base import DFTransformer, LoggableMixin
+from automatminer.utils.pkg import AutomatminerError
 from sklearn.base import is_classifier
-from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier, \
-    GradientBoostingClassifier, GradientBoostingRegressor
-from sklearn.model_selection import check_cv, train_test_split
-from sklearn.metrics import accuracy_score, roc_auc_score
+from sklearn.ensemble import (
+    GradientBoostingClassifier,
+    GradientBoostingRegressor,
+    RandomForestClassifier,
+    RandomForestRegressor,
+)
 from sklearn.linear_model import SGDClassifier
+from sklearn.metrics import accuracy_score, roc_auc_score
+from sklearn.model_selection import check_cv, train_test_split
 from sklearn.preprocessing import LabelEncoder
 from skrebate import MultiSURFstar
 
-from automatminer.utils.pkg import AutomatminerError
-from automatminer.base import LoggableMixin, DFTransformer
-
-__authors__ = ["Alireza Faghaninia <alireza@lbl.gov>",
-               "Alex Dunn <ardunn@lbl.gov>"]
+__authors__ = ["Alireza Faghaninia <alireza@lbl.gov>", "Alex Dunn <ardunn@lbl.gov>"]
 
 # Used in compare_coff_clf, declared here to prevent repeated obj creation
 COMMON_CLF = SGDClassifier()
@@ -37,8 +39,7 @@ class TreeFeatureReducer(DFTransformer, LoggableMixin):
             used. If set to False, then no logging will occur.
     """
 
-    def __init__(self, mode, importance_percentile=0.95,
-                 logger=True, random_state=0):
+    def __init__(self, mode, importance_percentile=0.95, logger=True, random_state=0):
         self.logger = logger
         self.mode = mode
         self.importance_percentile = importance_percentile
@@ -87,18 +88,19 @@ class TreeFeatureReducer(DFTransformer, LoggableMixin):
             tree_model.fit(X, y)
             fimportance = sorted(
                 zip(X.columns, tree_model.feature_importances_),
-                key=lambda x: x[1], reverse=True)
+                key=lambda x: x[1],
+                reverse=True,
+            )
             tfeats = self.get_top_features(fimportance)
             m_curr = len(tfeats)
             m_prev = len(X.columns)
-            self.logger.debug('nfeatures: {}->{}'.format(
-                len(X.columns), m_curr))
+            self.logger.debug("nfeatures: {}->{}".format(len(X.columns), m_curr))
             X = X[tfeats]
             if not recursive:
                 break
         return tfeats
 
-    def fit(self, X, y, tree='rf', recursive=True, cv=5):
+    def fit(self, X, y, tree="rf", recursive=True, cv=5):
         """
         Fits to the data (X) and target (y) to determine the selected_features.
 
@@ -119,19 +121,18 @@ class TreeFeatureReducer(DFTransformer, LoggableMixin):
         """
         m0 = len(X.columns)
         if isinstance(tree, str):
-            if tree.lower() in ['rf', 'random forest', 'randomforest']:
-                if self.mode.lower() in ['classification', 'classifier']:
+            if tree.lower() in ["rf", "random forest", "randomforest"]:
+                if self.mode.lower() in ["classification", "classifier"]:
                     tree = RandomForestClassifier(random_state=self.rs)
                 else:
                     tree = RandomForestRegressor(random_state=self.rs)
-            elif tree.lower() in ['gb', 'gbt', 'gradiet boosting']:
-                if self.mode.lower() in ['classification', 'classifier']:
+            elif tree.lower() in ["gb", "gbt", "gradiet boosting"]:
+                if self.mode.lower() in ["classification", "classifier"]:
                     tree = GradientBoostingClassifier(random_state=self.rs)
                 else:
                     tree = GradientBoostingRegressor(random_state=self.rs)
             else:
-                raise AutomatminerError(
-                    'Unsupported tree_type {}!'.format(tree))
+                raise AutomatminerError("Unsupported tree_type {}!".format(tree))
 
         cv = check_cv(cv=cv, y=y, classifier=is_classifier(tree))
         all_feats = []
@@ -142,9 +143,10 @@ class TreeFeatureReducer(DFTransformer, LoggableMixin):
         # take the union of selected features of each fold
         self.selected_features = list(set(all_feats))
         self.logger.info(
-            self._log_prefix +
-            'Finished tree-based feature reduction of {} initial features to '
-            '{}'.format(m0, len(self.selected_features)))
+            self._log_prefix
+            + "Finished tree-based feature reduction of {} initial features to "
+            "{}".format(m0, len(self.selected_features))
+        )
         return self
 
     def transform(self, X, y=None):
@@ -160,7 +162,7 @@ class TreeFeatureReducer(DFTransformer, LoggableMixin):
         Returns (pandas.DataFrame): the data with reduced number of features.
         """
         if self.selected_features is None:
-            raise AutomatminerError('The fit method should be called first!')
+            raise AutomatminerError("The fit method should be called first!")
         return X[self.selected_features]
 
 
@@ -212,8 +214,7 @@ def lower_corr_clf(df, target, f1, f2):
     features = [f1, f2]
     comparison_res = {}
     for i, x in enumerate([x1, x2]):
-        x_tr, x_te, y_tr, y_te = train_test_split(x, y, test_size=0.3,
-                                                  random_state=0)
+        x_tr, x_te, y_tr, y_te = train_test_split(x, y, test_size=0.3, random_state=0)
         COMMON_CLF.fit(x_tr, y_tr)
         y_pred = COMMON_CLF.predict(x_te)
         if len(unique_names) <= 2:

--- a/automatminer/preprocessing/tests/test_core.py
+++ b/automatminer/preprocessing/tests/test_core.py
@@ -4,11 +4,13 @@ from copy import deepcopy
 
 import numpy as np
 import pandas as pd
-
-from automatminer.utils.log import AMM_LOGGER_BASENAME
 from automatminer.preprocessing.core import DataCleaner, FeatureReducer
-from automatminer.preprocessing.feature_selection import TreeFeatureReducer, \
-    rebate, lower_corr_clf
+from automatminer.preprocessing.feature_selection import (
+    TreeFeatureReducer,
+    lower_corr_clf,
+    rebate,
+)
+from automatminer.utils.log import AMM_LOGGER_BASENAME
 from automatminer.utils.pkg import compare_columns
 
 test_dir = os.path.dirname(__file__)
@@ -16,9 +18,9 @@ test_dir = os.path.dirname(__file__)
 
 class TestPreprocess(unittest.TestCase):
     def setUp(self):
-        df = pd.read_csv(os.path.join(test_dir, 'test_featurized_df.csv'))
+        df = pd.read_csv(os.path.join(test_dir, "test_featurized_df.csv"))
         self._test_df = df.drop(columns=["formula"])
-        self.target = 'gap expt'
+        self.target = "gap expt"
 
     @property
     def test_df(self):
@@ -51,7 +53,7 @@ class TestPreprocess(unittest.TestCase):
         self.assertEqual(df.shape[0], self.test_df.shape[0] - 1)
 
         # Test if there is an nan in feature
-        df['HOMO_energy'].iloc[40] = np.nan
+        df["HOMO_energy"].iloc[40] = np.nan
         df = dc.fit_transform(df, self.target)
         self.assertEqual(df.shape[0], self.test_df.shape[0] - 2)
 
@@ -64,20 +66,21 @@ class TestPreprocess(unittest.TestCase):
         df2 = self.test_df
         df2 = df2.drop(columns=[self.target])
         df2 = dc.transform(df2, self.target)
-        self.assertFalse(compare_columns(df, df2,
-                                         ignore=self.target)["mismatch"])
+        self.assertFalse(compare_columns(df, df2, ignore=self.target)["mismatch"])
         self.assertTrue(self.target not in df2.columns)
 
     def test_DataCleaner_sample_na_method(self):
         df = self.test_df
-        df['HOMO_energy'].loc[40] = np.nan
-        df['HOMO_energy'].loc[110] = np.nan
+        df["HOMO_energy"].loc[40] = np.nan
+        df["HOMO_energy"].loc[110] = np.nan
 
         # Test when transform method is fill
-        dc = DataCleaner(max_na_frac=0.9,
-                         feature_na_method="drop",
-                         na_method_fit="drop",
-                         na_method_transform="fill")
+        dc = DataCleaner(
+            max_na_frac=0.9,
+            feature_na_method="drop",
+            na_method_fit="drop",
+            na_method_transform="fill",
+        )
         dffit = df.loc[:100]
         fitted = dc.fit_transform(dffit, target=self.target)
         test_shape = tuple(np.subtract(dffit.shape, (1, 0)).tolist())
@@ -88,10 +91,12 @@ class TestPreprocess(unittest.TestCase):
         self.assertTupleEqual(tranz.shape, dftrans.shape)
 
         # Test when transform method is mean
-        dc2 = DataCleaner(max_na_frac=0.9,
-                          feature_na_method="drop",
-                          na_method_fit="drop",
-                          na_method_transform="mean")
+        dc2 = DataCleaner(
+            max_na_frac=0.9,
+            feature_na_method="drop",
+            na_method_fit="drop",
+            na_method_transform="mean",
+        )
         fitted = dc2.fit_transform(dffit, target=self.target)
         test_shape = tuple(np.subtract(dffit.shape, (1, 0)).tolist())
         self.assertTupleEqual(fitted.shape, test_shape)  # minus one sample
@@ -105,8 +110,8 @@ class TestPreprocess(unittest.TestCase):
     def test_DataCleaner_feature_na_method(self):
         dc = DataCleaner(max_na_frac=0, feature_na_method="drop")
         df = self.test_df
-        df['LUMO_energy'].iloc[40] = np.nan
-        df['LUMO_energy'].iloc[110] = np.nan
+        df["LUMO_energy"].iloc[40] = np.nan
+        df["LUMO_energy"].iloc[110] = np.nan
 
         # Test normal dropping with transformation
         dffit = df.iloc[:100]
@@ -126,16 +131,19 @@ class TestPreprocess(unittest.TestCase):
 
         # Test mean
         dcmean = DataCleaner(max_na_frac=0, feature_na_method="mean")
-        df['minimum X'].iloc[99] = np.nan
+        df["minimum X"].iloc[99] = np.nan
         minimum_x = dffit["minimum X"]
         mean_min_x = minimum_x[~minimum_x.isnull()].mean()
         fitted = dcmean.fit_transform(dffit, target=self.target)
-        self.assertAlmostEqual(fitted["minimum X"].iloc[99], mean_min_x,
-                               places=10)
+        self.assertAlmostEqual(fitted["minimum X"].iloc[99], mean_min_x, places=10)
 
     def test_DataCleaner_na_method_feature_sample_interaction(self):
-        dc = DataCleaner(max_na_frac=0.01, feature_na_method="mean",
-                         na_method_transform="fill", na_method_fit="fill")
+        dc = DataCleaner(
+            max_na_frac=0.01,
+            feature_na_method="mean",
+            na_method_transform="fill",
+            na_method_fit="fill",
+        )
         df = self.test_df
         # Should be dropped
         df["maximum X"] = [np.nan] * len(df)
@@ -171,8 +179,7 @@ class TestPreprocess(unittest.TestCase):
         dc.fit(fit_df, self.target)
 
         trs_df2 = dc.transform(trs_df, self.target)
-        self.assertAlmostEqual(trs_df2["range X"].mean(),
-                               fit_df["range X"].mean())
+        self.assertAlmostEqual(trs_df2["range X"].mean(), fit_df["range X"].mean())
         self.assertAlmostEqual(trs_df2["range X"].std(), 0.0)
 
     def test_DataCleaner_big_nan_handler_warning(self):
@@ -180,8 +187,9 @@ class TestPreprocess(unittest.TestCase):
         number of nan samples and fraction is high (i.e., something
         has gone horribly wrong in featurization!)"""
         dc = DataCleaner(max_na_frac=0.01)
-        df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)),
-                          columns=list('ABCD'))
+        df = pd.DataFrame(
+            np.random.randint(0, 100, size=(100, 4)), columns=list("ABCD")
+        )
         dc.fit(df, "D")
         self.assertEqual(len(dc.warnings), 0)
 
@@ -191,7 +199,7 @@ class TestPreprocess(unittest.TestCase):
         self.assertEqual(len(dc.warnings), 1)
 
     def test_FeatureReducer_basic(self):
-        fr = FeatureReducer(reducers=('corr', 'tree'))
+        fr = FeatureReducer(reducers=("corr", "tree"))
 
         # ultra-basic case: are we reducing at least 1 feature?
         df = fr.fit_transform(self.test_df, self.target)
@@ -203,14 +211,14 @@ class TestPreprocess(unittest.TestCase):
 
     def test_FeatureReducer_advanced(self):
         # ensure other combinations of feature reducers are working
-        fr = FeatureReducer(reducers=('corr', 'rebate'), n_rebate_features=40)
+        fr = FeatureReducer(reducers=("corr", "rebate"), n_rebate_features=40)
         df = fr.fit_transform(self.test_df, self.target)
         self.assertEqual(df.shape[1], 41)  # 40 features + self.target
         self.assertTrue(self.target in df.columns)
 
     def test_FeatureReducer_transferability(self):
         # ensure the same thing works when fraction is used
-        fr = FeatureReducer(reducers=('rebate',), n_rebate_features=0.2)
+        fr = FeatureReducer(reducers=("rebate",), n_rebate_features=0.2)
         df = fr.fit_transform(self.test_df, self.target)
         self.assertEqual(df.shape[1], 83 + 1)
 
@@ -221,83 +229,98 @@ class TestPreprocess(unittest.TestCase):
 
     def test_FeatureReducer_classification(self):
         # test classification with corr matrix (no errors)
-        fr = FeatureReducer(reducers=('corr',))
+        fr = FeatureReducer(reducers=("corr",))
         df_class = self.test_df
-        df_class[self.target] = ["semiconductor" if 0.0 < g < 3.0 else
-                                 "nonmetal" for g in df_class[self.target]]
+        df_class[self.target] = [
+            "semiconductor" if 0.0 < g < 3.0 else "nonmetal"
+            for g in df_class[self.target]
+        ]
         df_class = fr.fit_transform(df_class, self.target)
         self.assertEqual(df_class.shape[0], 200)
 
     def test_FeatureReducer_combinations(self):
         df = self.test_df
-        fr = FeatureReducer(reducers=('pca', 'rebate', 'tree'))
+        fr = FeatureReducer(reducers=("pca", "rebate", "tree"))
         df_reduced = fr.fit_transform(df, self.target)
         self.assertGreater(df.shape[1], df_reduced.shape[1])
 
     def test_FeatureReducer_pca(self):
         # Case where n_samples < n_features
         df = self.test_df.iloc[:10]
-        fr = FeatureReducer(reducers=("pca",), n_pca_features='auto')
+        fr = FeatureReducer(reducers=("pca",), n_pca_features="auto")
         df_reduced = fr.fit_transform(df, self.target)
         self.assertTupleEqual(df_reduced.shape, (10, 11))
 
         # Case where n_samples > n_features
-        fsubset = ['HOMO_energy', 'LUMO_energy', 'gap_AO', 'minimum X',
-                   'maximum X', 'range X', 'mean X', 'std_dev X', 'minimum row',
-                   'maximum row', 'range row', 'mean row', 'std_dev row',
-                   'minimum group', 'maximum group', 'range group',
-                   'mean group', 'std_dev group']
+        fsubset = [
+            "HOMO_energy",
+            "LUMO_energy",
+            "gap_AO",
+            "minimum X",
+            "maximum X",
+            "range X",
+            "mean X",
+            "std_dev X",
+            "minimum row",
+            "maximum row",
+            "range row",
+            "mean row",
+            "std_dev row",
+            "minimum group",
+            "maximum group",
+            "range group",
+            "mean group",
+            "std_dev group",
+        ]
         df = self.test_df[fsubset + [self.target]]
         df_reduced = fr.fit_transform(df, self.target)
         self.assertEqual(df_reduced.shape[0], 200)
 
         # Manually specified case of n_samples > n_features
-        fr = FeatureReducer(reducers=('pca',), n_pca_features=0.5)
+        fr = FeatureReducer(reducers=("pca",), n_pca_features=0.5)
         df = self.test_df
         df_reduced = fr.fit_transform(df, self.target)
         self.assertTupleEqual(df_reduced.shape, (200, 201))
 
     def test_manual_feature_reduction(self):
-        fr = FeatureReducer(reducers=[], remove_features=['LUMO_element_Th'])
+        fr = FeatureReducer(reducers=[], remove_features=["LUMO_element_Th"])
 
         # ultra-basic case: are we reducing at least 1 feature?
         df = fr.fit_transform(self.test_df, self.target)
-        self.assertTrue('LUMO_element_Th' not in df.columns)
-        self.assertEqual(fr.removed_features['manual'], ['LUMO_element_Th'])
+        self.assertTrue("LUMO_element_Th" not in df.columns)
+        self.assertEqual(fr.removed_features["manual"], ["LUMO_element_Th"])
 
         # test removing feature that doesn't exist
-        fr = FeatureReducer(reducers=[], remove_features=['abcdefg12345!!'])
+        fr = FeatureReducer(reducers=[], remove_features=["abcdefg12345!!"])
 
-        with self.assertLogs(AMM_LOGGER_BASENAME, level='INFO') as cm:
+        with self.assertLogs(AMM_LOGGER_BASENAME, level="INFO") as cm:
             # should give log warning but not throw an error
             fr.fit_transform(self.test_df, self.target)
-            self.assertTrue('abcdefg12345!!' in " ".join(cm.output))
+            self.assertTrue("abcdefg12345!!" in " ".join(cm.output))
 
     def test_saving_feature_from_removal(self):
-        fr = FeatureReducer(reducers=('corr',), keep_features=['maximum X'])
+        fr = FeatureReducer(reducers=("corr",), keep_features=["maximum X"])
 
         # ultra-basic case: are we reducing at least 1 feature?
         df = fr.fit_transform(self.test_df, self.target)
-        self.assertTrue('maximum X' in df.columns)
+        self.assertTrue("maximum X" in df.columns)
 
 
 class TestFeatureReduction(unittest.TestCase):
-
     def setUp(self):
-        df = pd.read_csv(os.path.join(test_dir, 'test_featurized_df.csv'))
-        self.test_df = df.set_index('formula')
+        df = pd.read_csv(os.path.join(test_dir, "test_featurized_df.csv"))
+        self.test_df = df.set_index("formula")
         self.random_state = 12
 
     def test_TreeBasedFeatureReduction(self):
-        X = self.test_df.drop('gap expt', axis=1)
-        y = self.test_df['gap expt']
-        tbfr = TreeFeatureReducer(mode='regression',
-                                  random_state=self.random_state)
+        X = self.test_df.drop("gap expt", axis=1)
+        y = self.test_df["gap expt"]
+        tbfr = TreeFeatureReducer(mode="regression", random_state=self.random_state)
         tbfr.fit(X, y, cv=3)
         self.assertEqual(len(tbfr.selected_features), 19)
         X_reduced = tbfr.transform(X)
         self.assertEqual(X_reduced.shape, (len(X), 19))
-        self.assertTrue('HOMO_energy' in X_reduced.columns)
+        self.assertTrue("HOMO_energy" in X_reduced.columns)
 
     def test_rebate(self):
         df_reduced = rebate(self.test_df, "gap expt", 10)

--- a/automatminer/presets.py
+++ b/automatminer/presets.py
@@ -4,16 +4,15 @@ Configurations for MatPipe.
 
 __author__ = ["Alex Dunn <ardunn@lbl.gov>"]
 
-from xgboost import XGBRegressor, XGBClassifier
-from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier
-
+from automatminer.automl import SinglePipelineAdaptor, TPOTAdaptor
 from automatminer.featurization import AutoFeaturizer
-from automatminer.preprocessing import FeatureReducer, DataCleaner
-from automatminer.automl import TPOTAdaptor, SinglePipelineAdaptor
+from automatminer.preprocessing import DataCleaner, FeatureReducer
 from automatminer.utils.log import AMM_DEFAULT_LOGGER
+from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+from xgboost import XGBClassifier, XGBRegressor
 
 
-def get_preset_config(preset: str = 'express', **powerups) -> dict:
+def get_preset_config(preset: str = "express", **powerups) -> dict:
     """
     Preset configs for MatPipe.
 
@@ -49,59 +48,59 @@ def get_preset_config(preset: str = 'express', **powerups) -> dict:
 
     elif preset == "production":
         config = {
-            "learner": TPOTAdaptor(max_time_mins=1440,
-                                   max_eval_time_mins=20),
-            "reducer": FeatureReducer(reducers=('corr', 'tree'),
-                                      tree_importance_percentile=0.99),
-            "autofeaturizer": AutoFeaturizer(preset="express",
-                                             **caching_kwargs),
-            "cleaner": DataCleaner()
+            "learner": TPOTAdaptor(max_time_mins=1440, max_eval_time_mins=20),
+            "reducer": FeatureReducer(
+                reducers=("corr", "tree"), tree_importance_percentile=0.99
+            ),
+            "autofeaturizer": AutoFeaturizer(preset="express", **caching_kwargs),
+            "cleaner": DataCleaner(),
         }
     elif preset == "heavy":
         config = {
             "learner": TPOTAdaptor(max_time_mins=2880),
             "reducer": FeatureReducer(reducers=("corr", "rebate")),
             "autofeaturizer": AutoFeaturizer(preset="heavy", **caching_kwargs),
-            "cleaner": DataCleaner()
+            "cleaner": DataCleaner(),
         }
     elif preset == "express":
         config = {
             "learner": TPOTAdaptor(max_time_mins=60, population_size=20),
-            "reducer": FeatureReducer(reducers=('corr', 'tree'),
-                                      tree_importance_percentile=0.99),
-            "autofeaturizer": AutoFeaturizer(preset="express",
-                                             **caching_kwargs),
-            "cleaner": DataCleaner()
+            "reducer": FeatureReducer(
+                reducers=("corr", "tree"), tree_importance_percentile=0.99
+            ),
+            "autofeaturizer": AutoFeaturizer(preset="express", **caching_kwargs),
+            "cleaner": DataCleaner(),
         }
     elif preset == "express_single":
         xgb_kwargs = {"n_estimators": 300, "max_depth": 3, "n_jobs": -1}
         config = {
             "learner": SinglePipelineAdaptor(
                 regressor=XGBRegressor(**xgb_kwargs),
-                classifier=XGBClassifier(**xgb_kwargs)),
-            "reducer": FeatureReducer(reducers=('corr',)),
-            "autofeaturizer": AutoFeaturizer(preset="express",
-                                             **caching_kwargs),
-            "cleaner": DataCleaner()
+                classifier=XGBClassifier(**xgb_kwargs),
+            ),
+            "reducer": FeatureReducer(reducers=("corr",)),
+            "autofeaturizer": AutoFeaturizer(preset="express", **caching_kwargs),
+            "cleaner": DataCleaner(),
         }
     elif preset == "debug":
         config = {
-            "learner": TPOTAdaptor(max_time_mins=1,
-                                   max_eval_time_mins=1,
-                                   population_size=10),
-            "reducer": FeatureReducer(reducers=('corr', 'tree')),
+            "learner": TPOTAdaptor(
+                max_time_mins=1, max_eval_time_mins=1, population_size=10
+            ),
+            "reducer": FeatureReducer(reducers=("corr", "tree")),
             "autofeaturizer": AutoFeaturizer(preset="debug", **caching_kwargs),
-            "cleaner": DataCleaner()
+            "cleaner": DataCleaner(),
         }
     elif preset == "debug_single":
         rf_kwargs = {"n_estimators": 10, "n_jobs": -1}
         config = {
             "learner": SinglePipelineAdaptor(
                 classifier=RandomForestClassifier(**rf_kwargs),
-                regressor=RandomForestRegressor(**rf_kwargs)),
-            "reducer": FeatureReducer(reducers=('corr',)),
+                regressor=RandomForestRegressor(**rf_kwargs),
+            ),
+            "reducer": FeatureReducer(reducers=("corr",)),
             "autofeaturizer": AutoFeaturizer(preset="debug", **caching_kwargs),
-            "cleaner": DataCleaner()
+            "cleaner": DataCleaner(),
         }
 
     logger = powerups.get("logger", AMM_DEFAULT_LOGGER)
@@ -116,11 +115,4 @@ def get_available_presets():
     Returns:
         ([str]): A list of preset names.
     """
-    return [
-        "production",
-        "heavy",
-        "express",
-        "express_single",
-        "debug",
-        "debug_single"
-    ]
+    return ["production", "heavy", "express", "express_single", "debug", "debug_single"]

--- a/automatminer/tests/test_base.py
+++ b/automatminer/tests/test_base.py
@@ -1,14 +1,13 @@
 """
 Tests for the base classes.
 """
-import unittest
 import logging
+import unittest
 
 import pandas as pd
-from sklearn.exceptions import NotFittedError
-
 from automatminer.base import DFTransformer, LoggableMixin
 from automatminer.utils.pkg import check_fitted, set_fitted
+from sklearn.exceptions import NotFittedError
 
 
 class TestTransformerGood(DFTransformer):
@@ -81,26 +80,25 @@ class TestLoggableMixin(LoggableMixin):
 
 
 class TestBaseTransformers(unittest.TestCase):
-
     def setUp(self):
-        self.df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6], 'c': [7, 8, 9]})
+        self.df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
 
     def test_DFTransformer(self):
         ttg = TestTransformerGood(5)
         self.assertTrue(hasattr(ttg, "config_attr"))
         self.assertTrue(ttg.config_attr, 5)
         with self.assertRaises(NotFittedError):
-            ttg.transform(self.df, 'b')
+            ttg.transform(self.df, "b")
 
-        ttg.fit(self.df, 'a')
+        ttg.fit(self.df, "a")
         self.assertTrue(ttg.config_attr, 5)
 
-        test = ttg.transform(self.df, 'b')
+        test = ttg.transform(self.df, "b")
         self.assertTrue("b" in test.columns)
         self.assertTrue("c" in test.columns)
         self.assertTrue("a" not in test.columns)
 
-        test = ttg.fit_transform(self.df, 'c')
+        test = ttg.fit_transform(self.df, "c")
         self.assertTrue("c" not in test.columns)
         self.assertTrue("a" in test.columns)
         self.assertTrue("b" in test.columns)

--- a/automatminer/tests/test_pipeline.py
+++ b/automatminer/tests/test_pipeline.py
@@ -2,18 +2,17 @@
 Tests for the top level interface.
 """
 
-import unittest
 import os.path
+import unittest
 
 import pandas as pd
-from matminer.datasets.dataset_retrieval import load_dataset
-from sklearn.metrics import r2_score
-from sklearn.exceptions import NotFittedError
-from sklearn.model_selection import KFold
-
 from automatminer.pipeline import MatPipe
-from automatminer.presets import get_preset_config, get_available_presets
-from automatminer.utils.pkg import AutomatminerError, AMM_SUPPORTED_EXTS
+from automatminer.presets import get_available_presets, get_preset_config
+from automatminer.utils.pkg import AMM_SUPPORTED_EXTS, AutomatminerError
+from matminer.datasets.dataset_retrieval import load_dataset
+from sklearn.exceptions import NotFittedError
+from sklearn.metrics import r2_score
+from sklearn.model_selection import KFold
 
 test_dir = os.path.dirname(__file__)
 CACHE_SRC = os.path.join(test_dir, "cache.json")
@@ -24,11 +23,11 @@ DIGEST_PATH = os.path.join(test_dir, "matdigest")
 
 class TestMatPipeSetup(unittest.TestCase):
     def setUp(self):
-        self.config = get_preset_config('debug')
+        self.config = get_preset_config("debug")
 
     def test_instantiation(self):
-        learner = self.config['learner']
-        autofeaturizer = self.config['autofeaturizer']
+        learner = self.config["learner"]
+        autofeaturizer = self.config["autofeaturizer"]
         with self.assertRaises(AutomatminerError):
             MatPipe(learner=learner)
         with self.assertRaises(AutomatminerError):
@@ -74,22 +73,20 @@ def make_matpipe_test(config_preset, skip=None):
         skip = []
     for s in skip:
         if s not in skippables:
-            raise ValueError(
-                f"{s} is not a skippable test. Choose from {skippables}"
-            )
+            raise ValueError(f"{s} is not a skippable test. Choose from {skippables}")
     reason = "Skip was requested."
 
     class TestMatPipe(unittest.TestCase):
         def setUp(self):
             df = load_dataset("elastic_tensor_2015").rename(
-                columns={"formula": "composition"})
+                columns={"formula": "composition"}
+            )
             self.df = df[["composition", "K_VRH"]]
             self.df_struc = df[["composition", "structure", "K_VRH"]]
             self.extra_features = df["G_VRH"]
             self.target = "K_VRH"
             self.config = get_preset_config(config_preset)
-            self.config_cached = get_preset_config(config_preset,
-                                                   cache_src=CACHE_SRC)
+            self.config_cached = get_preset_config(config_preset, cache_src=CACHE_SRC)
             self.pipe = MatPipe(**self.config)
             self.pipe_cached = MatPipe(**self.config_cached)
 
@@ -132,7 +129,6 @@ def make_matpipe_test(config_preset, skip=None):
             test = df_test[self.target + " predicted"]
             self.assertTrue(r2_score(true, test) > 0.75)
 
-
         @unittest.skipIf("ignore" in skip, reason)
         def test_ignore(self):
             df = self.df
@@ -163,7 +159,6 @@ def make_matpipe_test(config_preset, skip=None):
             predicted_some = self.pipe.predict(df_test, ignore=some)
             self.assertFalse(ef in predicted_some.columns)
             self.assertTrue("composition" in predicted_some.columns)
-
 
         @unittest.skipIf("benchmarking" in skip, reason)
         def test_benchmarking_no_cache(self):
@@ -231,8 +226,9 @@ def make_matpipe_test(config_preset, skip=None):
 
             # Test static subset of kfold
             df2 = self.df.iloc[500:550]
-            df_tests2 = pipe.benchmark(df2, self.target, kfold,
-                                       fold_subset=[0, 3], cache=cache)
+            df_tests2 = pipe.benchmark(
+                df2, self.target, kfold, fold_subset=[0, 3], cache=cache
+            )
             self.assertEqual(len(df_tests2), 2)
 
         def tearDown(self) -> None:
@@ -244,8 +240,10 @@ def make_matpipe_test(config_preset, skip=None):
     return TestMatPipe
 
 
-@unittest.skipIf(int(os.environ.get("SKIP_INTENSIVE", 0)),
-                     "Test too intensive for CircleCI commit builds.")
+@unittest.skipIf(
+    int(os.environ.get("SKIP_INTENSIVE", 0)),
+    "Test too intensive for CircleCI commit builds.",
+)
 class MatPipeDebugTest(make_matpipe_test("debug")):
     pass
 

--- a/automatminer/utils/log.py
+++ b/automatminer/utils/log.py
@@ -2,10 +2,10 @@
 Utils for logging.
 """
 
+import datetime
+import logging
 import os
 import sys
-import logging
-import datetime
 
 AMM_LOGGER_BASENAME = "automatminer"
 AMM_LOG_FIT_STR = "fitting"
@@ -15,7 +15,7 @@ AMM_LOG_PREDICT_STR = "predicting"
 AMM_DEFAULT_LOGGER = True
 
 
-def initialize_logger(logger_name, log_dir='.', level=None) -> logging.Logger:
+def initialize_logger(logger_name, log_dir=".", level=None) -> logging.Logger:
     """Initialize the default logger with stdout and file handlers.
 
     Args:
@@ -28,15 +28,16 @@ def initialize_logger(logger_name, log_dir='.', level=None) -> logging.Logger:
     level = level or logging.INFO
 
     logger = logging.getLogger(logger_name)
-    formatter = logging.Formatter(fmt='%(asctime)s %(levelname)-8s %(message)s',
-                                  datefmt='%Y-%m-%d %H:%M:%S')
+    formatter = logging.Formatter(
+        fmt="%(asctime)s %(levelname)-8s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+    )
 
     logpath = os.path.join(log_dir, logger_name)
     if os.path.exists(logpath + ".log"):
-        logpath += "_" + datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
+        logpath += "_" + datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     logpath += ".log"
 
-    handler = logging.FileHandler(logpath, mode='w')
+    handler = logging.FileHandler(logpath, mode="w")
     handler.setFormatter(formatter)
     screen_handler = logging.StreamHandler(stream=sys.stdout)
     screen_handler.setFormatter(formatter)
@@ -87,12 +88,14 @@ def log_progress(operation):
             Return:
                 result: The method result.
             """
-            self = args[0]
-            self.logger.info("{}Starting {}.".format(self._log_prefix,
-                                                     operation))
+            instance = args[0]
+            instance.logger.info(
+                "{}Starting {}.".format(instance._log_prefix, operation)
+            )
             result = meth(*args, **kwargs)
-            self.logger.info("{}Finished {}.".format(self._log_prefix,
-                                                     operation))
+            instance.logger.info(
+                "{}Finished {}.".format(instance._log_prefix, operation)
+            )
             return result
 
         return wrapper

--- a/automatminer/utils/ml.py
+++ b/automatminer/utils/ml.py
@@ -5,11 +5,11 @@ Tools and utils for machine learning.
 import warnings
 
 import pandas as pd
-
 from automatminer.utils.pkg import AutomatminerError
 
 AMM_REG_NAME = "regression"
 AMM_CLF_NAME = "classification"
+
 
 def is_greater_better(scoring_function) -> bool:
     """
@@ -21,32 +21,53 @@ def is_greater_better(scoring_function) -> bool:
         it is larger or better if it is smaller
     """
     desired_high_metrics = {
-        'accuracy', 'adjusted_rand_score', 'average_precision',
-        'balanced_accuracy', 'f1', 'f1_macro', 'f1_micro', 'f1_samples',
-        'f1_weighted', 'precision', 'precision_macro', 'precision_micro',
-        'precision_samples', 'precision_weighted', 'recall',
-        'recall_macro', 'recall_micro', 'recall_samples',
-        'recall_weighted', 'roc_auc', 'r2', 'r2_score',
-        'neg_median_absolute_error', 'neg_mean_absolute_error',
-        'neg_mean_squared_error'
+        "accuracy",
+        "adjusted_rand_score",
+        "average_precision",
+        "balanced_accuracy",
+        "f1",
+        "f1_macro",
+        "f1_micro",
+        "f1_samples",
+        "f1_weighted",
+        "precision",
+        "precision_macro",
+        "precision_micro",
+        "precision_samples",
+        "precision_weighted",
+        "recall",
+        "recall_macro",
+        "recall_micro",
+        "recall_samples",
+        "recall_weighted",
+        "roc_auc",
+        "r2",
+        "r2_score",
+        "neg_median_absolute_error",
+        "neg_mean_absolute_error",
+        "neg_mean_squared_error",
     }
 
     desired_low_metrics = {
-        'median_absolute_error',
-        'mean_absolute_error',
-        'mean_squared_error'
+        "median_absolute_error",
+        "mean_absolute_error",
+        "mean_squared_error",
     }
 
     # Check to ensure no metrics are accidentally placed in both sets
     if desired_high_metrics.intersection(desired_low_metrics):
-        raise AutomatminerError("Error, there is a metric in both desired"
-                                " high and desired low metrics")
+        raise AutomatminerError(
+            "Error, there is a metric in both desired" " high and desired low metrics"
+        )
 
-    if scoring_function not in desired_high_metrics \
-            and scoring_function not in desired_low_metrics:
+    if (
+        scoring_function not in desired_high_metrics
+        and scoring_function not in desired_low_metrics
+    ):
         warnings.warn(
             'The scoring_function: "{}" not found; continuing assuming'
-            ' greater score is better'.format(scoring_function))
+            " greater score is better".format(scoring_function)
+        )
 
     # True if not in either set or only in desired_high,
     # False if in desired_low or both sets

--- a/automatminer/utils/pkg.py
+++ b/automatminer/utils/pkg.py
@@ -1,15 +1,14 @@
 """
 Utils specific to this package.
 """
-import os
 import json
+import os
 from pprint import pformat
 
-import yaml
 import pandas as pd
+import yaml
 from sklearn.exceptions import NotFittedError
 from sklearn.pipeline import Pipeline
-
 
 AMM_SUPPORTED_EXTS = [".txt", ".json", ".yaml", ".yml", ""]
 
@@ -51,14 +50,18 @@ def compare_columns(df1, df2, ignore=None) -> dict:
                  "mismatch": (bool)}
     """
     ignore = () if ignore is None else ignore
-    df2_not_in_df1 = [f for f in df2.columns if
-                      f not in df1.columns and f not in ignore]
-    df1_not_in_df2 = [f for f in df1.columns if
-                      f not in df2.columns and f not in ignore]
+    df2_not_in_df1 = [
+        f for f in df2.columns if f not in df1.columns and f not in ignore
+    ]
+    df1_not_in_df2 = [
+        f for f in df1.columns if f not in df2.columns and f not in ignore
+    ]
     matched = not (df2_not_in_df1 + df1_not_in_df2)
-    return {"df2_not_in_df1": df2_not_in_df1,
-            "df1_not_in_df2": df1_not_in_df2,
-            "mismatch": not matched}
+    return {
+        "df2_not_in_df1": df2_not_in_df1,
+        "df1_not_in_df2": df1_not_in_df2,
+        "mismatch": not matched,
+    }
 
 
 def check_fitted(func):
@@ -73,11 +76,13 @@ def check_fitted(func):
 
     def wrapper(*args, **kwargs):
         if not hasattr(args[0], "is_fit"):
-            raise AttributeError("Method using check_fitted has no is_fit attr"
-                                 " to check if fitted!")
+            raise AttributeError(
+                "Method using check_fitted has no is_fit attr" " to check if fitted!"
+            )
         if not args[0].is_fit:
-            raise NotFittedError("{} has not been fit!"
-                                 "".format(args[0].__class__.__name__))
+            raise NotFittedError(
+                "{} has not been fit!" "".format(args[0].__class__.__name__)
+            )
         else:
             return func(*args, **kwargs)
 
@@ -121,9 +126,11 @@ def return_attrs_recursively(obj) -> dict:
             if "automatminer" in value.__module__:
                 attrdict[attr] = {attr: return_attrs_recursively(value)}
             elif isinstance(value, pd.DataFrame):
-                attrdict[attr] = {"obj": value.__class__,
-                                  "columns": value.shape[1],
-                                  "samples": value.shape[0]}
+                attrdict[attr] = {
+                    "obj": value.__class__,
+                    "columns": value.shape[1],
+                    "samples": value.shape[0],
+                }
             elif isinstance(value, Pipeline):
                 attrdict[attr] = [str(s) for s in value.steps]
             else:
@@ -183,5 +190,5 @@ def get_version():
     with open(version_reference, "r") as f:
         init_file = f.readlines()
         v = [v for v in init_file if "__version__" in v][0]
-    v = v.replace("__version__", "").replace("\"", "").replace("=", "").strip()
+    v = v.replace("__version__", "").replace('"', "").replace("=", "").strip()
     return v

--- a/automatminer/utils/tests/test_log.py
+++ b/automatminer/utils/tests/test_log.py
@@ -2,19 +2,16 @@
 Test logging related utils.
 """
 
-import unittest
-import os
-
 import logging
+import os
+import unittest
 
-from automatminer.utils.log import initialize_logger, \
-    initialize_null_logger
+from automatminer.utils.log import initialize_logger, initialize_null_logger
 
 run_dir = os.getcwd()
 
 
 class TestLogTools(unittest.TestCase):
-
     def test_logger_initialization(self):
         logger_base_name = "TESTING"
         log = initialize_logger(logger_base_name, level=logging.DEBUG)
@@ -27,7 +24,7 @@ class TestLogTools(unittest.TestCase):
         log_file = os.path.join(run_dir, logger_base_name + ".log")
         self.assertTrue(os.path.isfile(log_file))
 
-        with open(log_file, 'r') as f:
+        with open(log_file, "r") as f:
             lines = f.readlines()
 
         self.assertTrue("logging" in lines[0])

--- a/automatminer/utils/tests/test_ml.py
+++ b/automatminer/utils/tests/test_ml.py
@@ -5,18 +5,20 @@ Tests for machine learning related utils.
 import unittest
 
 import pandas as pd
-
-from automatminer.utils.ml import is_greater_better, \
-    regression_or_classification, AMM_CLF_NAME, AMM_REG_NAME
+from automatminer.utils.ml import (
+    AMM_CLF_NAME,
+    AMM_REG_NAME,
+    is_greater_better,
+    regression_or_classification,
+)
 
 
 class TestMLTools(unittest.TestCase):
-
     def test_is_greater_better(self):
-        self.assertTrue(is_greater_better('accuracy'))
-        self.assertTrue(is_greater_better('r2_score'))
-        self.assertTrue(is_greater_better('neg_mean_squared_error'))
-        self.assertFalse(is_greater_better('mean_squared_error'))
+        self.assertTrue(is_greater_better("accuracy"))
+        self.assertTrue(is_greater_better("r2_score"))
+        self.assertTrue(is_greater_better("neg_mean_squared_error"))
+        self.assertFalse(is_greater_better("mean_squared_error"))
 
     def test_regression_or_classification(self):
         s = pd.Series(data=["4", "5", "6"])

--- a/automatminer/utils/tests/test_pkg.py
+++ b/automatminer/utils/tests/test_pkg.py
@@ -5,12 +5,17 @@ import os
 import unittest
 
 import pandas as pd
-from sklearn.exceptions import NotFittedError
-
 from automatminer import __version__
-from automatminer.utils.pkg import compare_columns, check_fitted, \
-    set_fitted, get_version, save_dict_to_file, AMM_SUPPORTED_EXTS
 from automatminer.base import DFTransformer
+from automatminer.utils.pkg import (
+    AMM_SUPPORTED_EXTS,
+    check_fitted,
+    compare_columns,
+    get_version,
+    save_dict_to_file,
+    set_fitted,
+)
+from sklearn.exceptions import NotFittedError
 
 
 class MyTransformer(DFTransformer):
@@ -27,7 +32,6 @@ class MyTransformer(DFTransformer):
 
 
 class TestPackageTools(unittest.TestCase):
-
     def setUp(self) -> None:
         self.remant_base_path = os.path.dirname(__file__)
         self.remant_file_prefix = "saved"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,7 @@
 # Requirements of this dev
 FireWorks==1.8.7
 GitPython==2.1.11
+black==19.3b0
+flake8==3.7.8
+isort==4.3.21
+pre-commit==1.18.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,12 @@
+[flake8]
+max-line-length = 100
+exclude = .git
+# E731: do not assign a lambda expression, use a def
+# W503: line break before binary operator
+ignore = E731, W503
+
+# Make isort play nicely with black's import formatting.
+# https://github.com/microsoft/vscode-python/issues/5840
+[isort]
+multi_line_output = 3
+include_trailing_comma = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [flake8]
-max-line-length = 100
+max-line-length = 79
+max-complexity = 12
 exclude = .git
 # E731: do not assign a lambda expression, use a def
 # W503: line break before binary operator


### PR DESCRIPTION
Closes #208.

Feel free to make edits, suggest changes (e.g. do you prefer different config options? note that `black` enforces double quotes and this is non-configurable) or close this PR outright as it wasn't that much work. Just thought I'd help get the ball rolling on #208.

I only ran autoformatting on a fairly random subselection of files. If you think this could eventually be merged, I'm happy to add all remaining unformatted files.

Tests passing locally:
```
============ 65 passed, 1 skipped, 774 warnings in 714.06s (0:11:54) ============
```